### PR TITLE
Add configure support for C++14 into SST

### DIFF
--- a/config/ax_cxx_compile_native_check.m4
+++ b/config/ax_cxx_compile_native_check.m4
@@ -7,7 +7,7 @@ AC_DEFUN([AX_CXX_COMPILE_NATIVE_CHECK], [
   save_CXXFLAGS="$CXXFLAGS"
   CXXFLAGS="$CXXFLAGS -march=native -mtune=native"
   AC_TRY_LINK([@%:@include <iostream>],
-                       [[const int n = 1024;
+                       [const int n = 1024;
 			double* thearray = (double*) malloc(sizeof(double) * n);
 			int c;
 			double sum = 0;
@@ -16,11 +16,63 @@ AC_DEFUN([AX_CXX_COMPILE_NATIVE_CHECK], [
 			for(c = 0; c < n; ++c) 
 				sum += thearray[c];
 
-			std::cout << "total is: " << sum << std::endl;]],
+			std::cout << "total is: " << sum << std::endl;],
   ax_cv_cxx_compile_native_check=yes, ax_cv_cxx_compile_native_check=no)
   CXXFLAGS="$save_CXXFLAGS"
   AC_LANG_RESTORE
   ])
 
   AS_IF( [test "$ax_cv_cxx_compile_native_check" = "yes"], [CXXFLAGS="$CXXFLAGS -march=native -mtune=native"] )
+
+  AS_IF([ test "x$ax_cv_cxx_compile_native_check" != "xyes" ], [
+	AC_CACHE_CHECK([if C++ AVX2 instruction selection is permitted by the compiler],
+  	ax_cv_cxx_compile_avx2_check,
+  	[AC_LANG_SAVE
+  	AC_LANG_CPLUSPLUS
+  	save_CXXFLAGS="$CXXFLAGS"
+  	CXXFLAGS="$CXXFLAGS -mavx2"
+  	AC_TRY_LINK([@%:@include <iostream>],
+                       [const int n = 1024;
+                        double* thearray = (double*) malloc(sizeof(double) * n);
+                        int c;
+                        double sum = 0;
+                        for(c = 0; c < n; ++c)
+                                thearray[c] = 1 + c;
+                        for(c = 0; c < n; ++c)
+                                sum += thearray[c];
+
+                        std::cout << "total is: " << sum << std::endl;],
+  	ax_cv_cxx_compile_avx2_check=yes, ax_cv_cxx_compile_avx2_check=no)
+  	CXXFLAGS="$save_CXXFLAGS"
+  	AC_LANG_RESTORE
+  	])
+
+	AS_IF( [test "$ax_cv_cxx_compile_avx2_check" = "yes"], [CXXFLAGS="$CXXFLAGS -mavx2"] )
+  ])
+
+  AS_IF([ test "x$ax_cv_cxx_compile_native_check" != "xyes" -a "x$ax_cv_cxx_compile_avx2_check" != "xyes" ], [
+	AC_CACHE_CHECK([if C++ AVX instruction selection is permitted by the compiler],
+  	ax_cv_cxx_compile_avx_check,
+  	[AC_LANG_SAVE
+  	AC_LANG_CPLUSPLUS
+  	save_CXXFLAGS="$CXXFLAGS"
+  	CXXFLAGS="$CXXFLAGS -mavx"
+  	AC_TRY_LINK([@%:@include <iostream>],
+                       [const int n = 1024;
+                        double* thearray = (double*) malloc(sizeof(double) * n);
+                        int c;
+                        double sum = 0;
+                        for(c = 0; c < n; ++c)
+                                thearray[c] = 1 + c;
+                        for(c = 0; c < n; ++c)
+                                sum += thearray[c];
+
+                        std::cout << "total is: " << sum << std::endl;],
+  	ax_cv_cxx_compile_avx_check=yes, ax_cv_cxx_compile_avx_check=no)
+  	CXXFLAGS="$save_CXXFLAGS"
+  	AC_LANG_RESTORE
+  	])
+
+	AS_IF( [test "$ax_cv_cxx_compile_avx_check" = "yes"], [CXXFLAGS="$CXXFLAGS -mavx"] )
+  ])
 ])

--- a/config/ax_cxx_compile_stdcxx_04.m4
+++ b/config/ax_cxx_compile_stdcxx_04.m4
@@ -112,14 +112,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_0X], [
   ])
 
   AS_IF( [test "$ax_cv_cxx_compile_cxx0x_native" = "yes" -o "$ax_cv_cxx_compile_cxx0x_cxx" = "yes" -o "$ax_cv_cxx_compile_cxx11_cxx" = "yes" ], 
-	[found_cxx="yes"], [found_cxx="no"] )
+	[found_cxx0x="yes"], [found_cxx0x="no"] )
 
-  AS_IF( [test "x$found_cxx" = "xno"],
-	[AC_MSG_ERROR([Could not found C++11 support but this is required for SST to successfully build.], [1]) ])
-
-  AC_DEFINE(HAVE_STDCXX_0X, [1], [Define if C++ supports C++11 features.])
+  AS_IF( [test "x$found_cxx1y" = "xno" -a "x$found_cxx0x" = "xno"],
+	[AC_MSG_ERROR([Could not found C++14 or C++11 support but this is required for SST to successfully build.], [1]) ])
   AC_SUBST([SST_CXX0X_FLAGS])
-  CXXFLAGS="$CXXFLAGS $SST_CXX0X_FLAGS"
-  AM_CONDITIONAL([HAVE_STDCXX_0X], [test "x$found_cxx" = "xyes"])
 ])
-

--- a/config/ax_cxx_compile_stdcxx_14.m4
+++ b/config/ax_cxx_compile_stdcxx_14.m4
@@ -52,7 +52,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_1Y], [
     check_type&& cr = static_cast<check_type&&>(c);],,
   ax_cv_cxx_compile_cxx_14_cxx=yes, ax_cv_cxx_compile_cxx_14_cxx=no)
   CXXFLAGS=$ac_save_CXXFLAGS
-  AS_IF([test "$ax_cv_cxx_compile_cxx_1y_cxx" = "yes" ], [SST_CXX1Y_FLAGS="-std=c++14"])
+  AS_IF([test "$ax_cv_cxx_compile_cxx_14_cxx" = "yes" ], [SST_CXX1Y_FLAGS="-std=c++14"])
 
   AC_LANG_RESTORE
   ])
@@ -89,11 +89,10 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_1Y], [
   ])
 
   AS_IF( [test "$ax_cv_cxx_compile_cxx1y_native" = "yes" -o "$ax_cv_cxx_compile_cxx1y_cxx" = "yes" -o "$ax_cv_cxx_compile_cxx14_cxx" = "yes" ], 
-	[found_cxx="yes"], [found_cxx="no"] )
+	[found_cxx1y="yes"], [found_cxx1y="no"] )
 
   AC_DEFINE(HAVE_STDCXX_1Y, [1], [Define if C++ supports C++14 features.])
   AC_SUBST([SST_CXX1Y_FLAGS])
-  CXXFLAGS="$CXXFLAGS $SST_CXX1Y_FLAGS"
-  AM_CONDITIONAL([HAVE_STDCXX_1Y], [test "x$found_cxx" = "xyes"])
+  AM_CONDITIONAL([HAVE_STDCXX_1Y], [test "x$found_cxx1y" = "xyes"])
 ])
 

--- a/config/ax_cxx_compile_stdcxx_14.m4
+++ b/config/ax_cxx_compile_stdcxx_14.m4
@@ -1,0 +1,99 @@
+
+AU_ALIAS([AC_CXX_COMPILE_STDCXX_1Y], [AX_CXX_COMPILE_STDCXX_1Y])
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_1Y], [
+  SST_CXX1Y_FLAGS=""
+
+  AC_CACHE_CHECK(if C++ supports C++1y features without additional flags,
+  ax_cv_cxx_compile_cxx1y_native,
+  [AC_LANG_SAVE
+  AC_LANG_CPLUSPLUS
+  AC_TRY_COMPILE([
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);],,
+  ax_cv_cxx_compile_cxx1y_native=yes, ax_cv_cxx_compile_cxx1y_native=no)
+  AC_LANG_RESTORE
+  ])
+
+  SST_CXX1Y_FLAGS=""
+
+  AC_CACHE_CHECK(if C++ supports C++1y features with -std=c++14,
+  ax_cv_cxx_compile_cxx14_cxx,
+  [AC_LANG_SAVE
+  AC_LANG_CPLUSPLUS
+  ac_save_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS -std=c++14"
+  AC_TRY_COMPILE([
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);],,
+  ax_cv_cxx_compile_cxx_14_cxx=yes, ax_cv_cxx_compile_cxx_14_cxx=no)
+  CXXFLAGS=$ac_save_CXXFLAGS
+  AS_IF([test "$ax_cv_cxx_compile_cxx_1y_cxx" = "yes" ], [SST_CXX1Y_FLAGS="-std=c++14"])
+
+  AC_LANG_RESTORE
+  ])
+
+  AS_IF([test "$ax_cv_cxx_compile_cxx14_cxx" != "yes"], [
+
+  AC_CACHE_CHECK(if C++ supports C++1y features with -std=c++1y,
+  ax_cv_cxx_compile_cxx1y_cxx,
+  [AC_LANG_SAVE
+  AC_LANG_CPLUSPLUS
+  ac_save_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS -std=c++1y"
+  AC_TRY_COMPILE([
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);],,
+  ax_cv_cxx_compile_cxx1y_cxx=yes, ax_cv_cxx_compile_cxx1y_cxx=no)
+  CXXFLAGS=$ac_save_CXXFLAGS
+  AS_IF([test "$ax_cv_cxx_compile_cxx1y_cxx" = "yes" ], [SST_CXX1Y_FLAGS="-std=c++1y"])
+  AC_LANG_RESTORE
+
+  ])
+  ])
+
+  AS_IF( [test "$ax_cv_cxx_compile_cxx1y_native" = "yes" -o "$ax_cv_cxx_compile_cxx1y_cxx" = "yes" -o "$ax_cv_cxx_compile_cxx14_cxx" = "yes" ], 
+	[found_cxx="yes"], [found_cxx="no"] )
+
+  AC_DEFINE(HAVE_STDCXX_1Y, [1], [Define if C++ supports C++14 features.])
+  AC_SUBST([SST_CXX1Y_FLAGS])
+  CXXFLAGS="$CXXFLAGS $SST_CXX1Y_FLAGS"
+  AM_CONDITIONAL([HAVE_STDCXX_1Y], [test "x$found_cxx" = "xyes"])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -89,8 +89,8 @@ AC_DEFINE_UNQUOTED([SST_WANT_POLYMORPHIC_ARCHIVE], [$want_polymorphic],
   [defined to 1 if want boost polymorphic serialization archives])
 
 AC_DEFINE_UNQUOTED([BOOST_LIBDIR], ["$BOOST_LIBDIR"], [Defines the location of the Boost libraries as an SST header definition] )
+AC_DEFINE_UNQUOTED([BOOST_CPPFLAGS], ["$BOOST_CPPFLAGS"], [Defines the location of the Boost header files as an SST define] )
 AC_DEFINE_UNQUOTED([SST_INSTALL_PREFIX], ["$prefix"], [Defines the location SST will be installed in])
-
 
 SST_CHECK_MEM_POOL()
 SST_CHECK_PARAM_WARNINGS()
@@ -291,6 +291,16 @@ fi
 
 AC_SUBST(SST_SVN_REVISION)
 AC_DEFINE_UNQUOTED([SST_SVN_REVISION], ["$SST_SVN_REVISION"], [SST SVN Revision])
+
+AC_DEFINE_UNQUOTED([SST_CPPFLAGS], ["$CPPFLAGS"], [C Preprocessor Flags used for SST])
+AC_DEFINE_UNQUOTED([SST_CFLAGS], ["$CFLAGS"], [C Flags used for SST])
+AC_DEFINE_UNQUOTED([SST_CXXFLAGS], ["$CXXFLAGS"], [C++ Flags used for SST])
+AC_DEFINE_UNQUOTED([SST_CC], ["$CC"], [C Compiler used for SST])
+AC_DEFINE_UNQUOTED([SST_CXX], ["$CXX"], [C++ Compiler used for SST])
+AC_DEFINE_UNQUOTED([SST_MPICC], ["$MPICC"], [MPI C Compiler used for SST])
+AC_DEFINE_UNQUOTED([SST_MPICXX], ["$MPICXX"], [MPI C++ Compiler used for SST])
+AC_DEFINE_UNQUOTED([SST_LD], ["$LD"], [Linker used for SST])
+AC_DEFINE_UNQUOTED([SST_LDFLAGS], ["$LDFLAGS"], [Linker Flags used for SST])
 
 AC_CONFIG_FILES([
   Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -40,8 +40,14 @@ AC_CACHE_SAVE
 AC_CHECK_PROG([DOXYGEN], [doxygen], [doxygen])
 AM_CONDITIONAL([HAVE_DOXYGEN], [test "$DOXYGEN" = "doxygen"])
 
-dnl Check for C++11 features
+dnl Check for C++11 and C++14 features
+AC_CXX_COMPILE_STDCXX_1Y
 AC_CXX_COMPILE_STDCXX_0X
+
+dnl Set the appropriate flags which have been discovered by the compiler detection
+AS_IF([test "x$found_cxx1y" = "xyes"],
+	[CXXFLAGS="$CXXFLAGS $SST_CXX1Y_FLAGS"],
+	[CXXFLAGS="$CXXFLAGS $SST_CXX0X_FLAGS"])
 
 dnl Check for the vendor of the compiler
 AX_CXX_COMPILE_DETECT
@@ -314,6 +320,13 @@ printf "%38s : %s\n" "Linker" "$LD"
 printf "%38s : %s\n" "Preprocessor Options" "$CPPFLAGS"
 printf "%38s : %s\n" "C Compiler Options" "$CFLAGS"
 printf "%38s : %s\n" "C++ Compiler Options" "$CXXFLAGS"
+
+if test "x$found_cxx1y" = "xyes"; then
+printf "%38s : %s\n" "C++ Standard Compliance" "C++1Y/14"
+else
+printf "%38s : %s\n" "C++ Standard Compliance" "C++11"
+fi
+
 printf "%38s : %s\n" "Linker Options" "$LDFLAGS"
 printf "%38s : %s\n" "Boost Library Preprocessor" "$BOOST_CPPFLAGS"
 printf "%38s : %s\n" "Boost Library Linker Options" "$BOOST_LDFLAGS"


### PR DESCRIPTION
Requested by a user, detects C++14 support and sets appropriate header file and Automake macros. 